### PR TITLE
v0.4.0 — the history release (integration branch)

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,101 @@
+# v0.4.0 — the history release
+
+**Integration branch.** Lanes merge here; this branch opens one PR against
+`main`. Per `AGENTS.md`, merging lanes into this branch is fine — the gate is
+`main`, and that gate needs explicit human approval.
+
+**Theme:** meridian's on-disk history becomes bounded — bounded writing,
+bounded reading, bounded retention — and every byte already written stays
+readable.
+
+Full plan, with reasoning and the cuts:
+`$MERIDIAN_CONTEXT_WORK_DIR/next-minor-planning/design/overview.md`
+(companions: `history-v2.md`, `derived-index.md`, `retention-archive.md`).
+
+## The governing constraint: read-compat, not write-compat
+
+`AGENTS.md`'s "no backwards compatibility" holds for *interfaces*. It does not
+hold for *data*. There is ~88 GB of live and ~115 GB of archived history in the
+current formats; a release that makes any of it unreadable is a failed release
+regardless of schema quality.
+
+- **Readers handle v1 and v2.** Version detection at one seam per store.
+- **Writers emit v2 only.** No dual-writes, no compat flags.
+- **Nothing migrates in place.** v1 files are never rewritten. The live v1
+  corpus shrinks by archive-then-prune, not conversion.
+
+## Release gate
+
+Before tagging: a read-only `meridian doctor --scan-history` canary over the
+full live corpus. It is the direct test of the one failure this release must
+not have.
+
+## Phases
+
+Arrows are hard ordering constraints. Everything else is independently
+landable.
+
+### R0 — safety (ships first; may ship as 0.3.x patches)
+
+- [ ] #475 stop mirroring spawn history into artifacts *(draft, in flight)*
+- [ ] Bounded `session search` — budget threaded into transcript parsing
+- [ ] #416 polling-consumer reorder + metadata-only reads
+
+`session search` currently hangs (full-parses every transcript to substring
+match). It is an open safety hole: the hang is what drove an agent to
+`ps | grep | xargs kill -9`, killing five live sessions. Ship it early.
+
+### R1 — history v2
+
+- [ ] **v2 envelope: meta split + `raw_text` drop + version tag + fixtures**
+      — one PR, cuts v0.4.0
+- [ ] #359 writer checkpoint (owns `seq`)
+- [ ] Finalization delta compaction
+
+**Must land together:** the meta split and the `raw_text` drop are one PR.
+Shipping the drop alone silently loses `session_id` / `uuid` / `timestamp_ms` /
+`toolCallId`, which live only in the wire envelope.
+
+`#475 → v2 envelope` (same write path). `#359 checkpoint → compaction`
+(compaction breaks the writer's `seq == line count` rehydration).
+
+### R2 — index and read paths
+
+- [ ] SQLite derived index + #360, **with the doctrine amendment in the same PR**
+- [ ] #417 finalization-scoped artifact context
+- [ ] #418 per-session state (stop replaying all of `sessions.jsonl`)
+- [ ] #129 `events.jsonl` + #274 + #439 reason field
+
+### R3 — recovery
+
+- [ ] `meridian session list`
+- [ ] Verified resolution + global chat-id counter
+- [ ] #165/#166/#171 identity at source, #378
+- [ ] `meridian ps` / `meridian kill`
+
+`session list → verified resolution` (failure messages point at the listing).
+
+### R4 — retention
+
+- [ ] `meridian archive` P1 (#473)
+- [ ] Archive-then-prune seam + #472 stderr cap + #445 GC
+
+`archive → prune`. Nothing prunes until the archiver's verify step exists. The
+reclaim invariant — delete only what a verified manifest proves archived —
+ports unchanged from the reference implementation.
+
+## Cuts under pressure
+
+First cut: R4 prune seam (the archiver alone plus manual reclaim covers another
+cycle). Second: `ps`/`kill` (bounded search already removes the trigger).
+
+**Do not cut** the v2 envelope, compaction, or the fixture corpus. They are the
+release.
+
+## Doctrine amendments landing in this release
+
+- `AGENTS.md` — "no backwards compatibility" scoped to interfaces, not data.
+- `AGENTS.md` / `.context/CONTEXT.md` — "no databases" amended: SQLite is
+  admitted as a *disposable derived cache* — rebuildable, deletable, never
+  believed over a disagreeing file, never a migration vehicle. Files remain the
+  only authority. Lands in the index PR, never separately.


### PR DESCRIPTION
## Why

meridian's on-disk history grew to 169 GB on a single machine, 99% of it
`history.jsonl`. Measured tonight: the `artifacts/` mirror was a full second
copy (81.8 GB), `raw_text` duplicates `payload` (42% of bytes), and streaming
deltas (53%) are superseded by `item/completed`. Meanwhile `meridian session
search` **hangs** — it full-parses every transcript to substring-match a corpus
`rg` scans in 23 seconds — and that hang is what drove an agent to
`ps | grep | xargs kill -9`, killing five live interactive sessions.

Nothing prunes. Nothing archives. Nothing indexes.

## Goal

One sentence: *v0.4.0 stops recording what it doesn't need, indexes what it
reads hot, archives what it no longer needs live, and guarantees the 200 GB
written under the old formats still reads.*

## Summary

**Integration branch.** Lanes merge here; this branch opens one PR against
`main`. Merging lanes into a task branch is fine per `AGENTS.md` — the gate is
`main`, and it needs explicit human approval.

The governing constraint is **read-compat, not write-compat**: readers handle
v1 and v2, writers emit v2 only, nothing migrates in place. `AGENTS.md`'s "no
backwards compatibility" holds for interfaces, not for data — there is ~88 GB
live and ~115 GB archived in current formats.

Phases (hard ordering constraints in `docs/releases/v0.4.0.md`):

- **R0 safety** — #475, bounded `session search`, #416. Ships first; may ship
  as 0.3.x patches since it carries no format change.
- **R1 history v2** — meta split + `raw_text` drop **in one PR** (splitting
  them silently loses `session_id`/`uuid`/`timestamp_ms`/`toolCallId`), #359
  writer checkpoint, finalization delta compaction.
- **R2 index** — SQLite derived index + #360, with the doctrine amendment in
  the same PR; #417, #418, #129/#274/#439.
- **R3 recovery** — `session list`, verified resolution + global chat-id
  counter, #378 identity at source, `meridian ps`/`kill`.
- **R4 retention** — `meridian archive` (#473), archive-then-prune seam,
  #472 stderr cap, #445 GC.

## Resulting Behavior

Per-file history drops from ~12.5 MB to ~2.5 MB. Live corpus 169 GB → ~25 GB
via archive-then-prune, never rewrite. `session search` returns instead of
hanging. Historical sessions stay readable and resolvable.

## Changes

This commit: the release tracking doc only. Implementation lands as lanes
merged into this branch.

## Work Item

`next-minor-planning` — full plan, cuts with reasoning, and PR/issue
reconciliation in the docs repo.

## Verification

**Release gate:** a read-only `meridian doctor --scan-history` canary over the
full live corpus before tagging — the direct test of the one failure this
release must not have.

Per-lane verification is each lane PR's responsibility: `uv run pytest-llm`,
`uv run ruff check .`, `uv run --extra dev python -m pyright` (0 errors).

## Knowledge Updates

Two doctrine amendments land in this release:

- `AGENTS.md` — "no backwards compatibility" scoped to interfaces, not data.
- `AGENTS.md` / `.context/CONTEXT.md` — "no databases" amended: SQLite admitted
  as a *disposable derived cache*, rebuildable and deletable, never believed
  over a disagreeing file, never a migration vehicle. Files remain the only
  authority. Lands in the index PR, never separately.

## Release Label Guide

`release:minor` — cuts v0.4.0.

## Post-Merge Automation

CI computes the next stable minor from git tags. Do not create or push tags
manually.

## Cleanup

Worktree `meridian-cli.worktrees/v0.4.0` removed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)